### PR TITLE
feat(Event): add UnityEvent Source Tracer editor window

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0de70ebd73f347478da8e9b6cc9a265
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation.meta
+++ b/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f429ed29e59018248b268f1bd6dd498a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API.meta
+++ b/Documentation/API.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1560e5096ca1cb54184deebbf80510fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Event.meta
+++ b/Documentation/API/Event.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fce833e11fbf0e2409c606e7cbee8a4c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Event/README.md
+++ b/Documentation/API/Event/README.md
@@ -1,0 +1,7 @@
+# Namespace Tilia.DeveloperTools.Event
+
+### Classes
+
+#### [UnityEventSourceTracer]
+
+[UnityEventSourceTracer]: UnityEventSourceTracer.md

--- a/Documentation/API/Event/README.md.meta
+++ b/Documentation/API/Event/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e84682e847df684097f2dc27e7baecf
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Event/UnityEventSourceTracer.md
+++ b/Documentation/API/Event/UnityEventSourceTracer.md
@@ -1,0 +1,43 @@
+# Class UnityEventSourceTracer
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [OnGUI()]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* UnityEventSourceTracer
+
+##### Namespace
+
+* [Tilia.DeveloperTools.Event]
+
+##### Syntax
+
+```
+public class UnityEventSourceTracer : EditorWindow
+```
+
+### Methods
+
+#### OnGUI()
+
+##### Declaration
+
+```
+public void OnGUI()
+```
+
+[Tilia.DeveloperTools.Event]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[OnGUI()]: #OnGUI

--- a/Documentation/API/Event/UnityEventSourceTracer.md.meta
+++ b/Documentation/API/Event/UnityEventSourceTracer.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e6efa118962fa44c986d04911f832ad
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Extension.meta
+++ b/Documentation/API/Extension.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a69757fbf832fc841868d9c20aef89af
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Extension/ObjectExtensions.md
+++ b/Documentation/API/Extension/ObjectExtensions.md
@@ -1,0 +1,102 @@
+# Class ObjectExtensions
+
+Extended methods for the System.Object Type.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [GetValue(Object, String)]
+  * [GetValue(Object, String, Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* ObjectExtensions
+
+##### Inherited Members
+
+System.Object.ToString()
+
+System.Object.Equals(System.Object)
+
+System.Object.Equals(System.Object, System.Object)
+
+System.Object.ReferenceEquals(System.Object, System.Object)
+
+System.Object.GetHashCode()
+
+System.Object.GetType()
+
+System.Object.MemberwiseClone()
+
+##### Namespace
+
+* [Tilia.DeveloperTools.Extension]
+
+##### Syntax
+
+```
+public static class ObjectExtensions
+```
+
+### Methods
+
+#### GetValue(Object, String)
+
+Gets the value for the given property name.
+
+##### Declaration
+
+```
+public static object GetValue(this object source, string name)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Object | source | The System.Object to retrieve from. |
+| System.String | name | The name of the property to retrieve. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Object | The found value. |
+
+#### GetValue(Object, String, Int32)
+
+Gets the value for the given property name.
+
+##### Declaration
+
+```
+public static object GetValue(this object source, string name, int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Object | source | The System.Object to retrieve from. |
+| System.String | name | The name of the property to retrieve. |
+| System.Int32 | index | The index to retrieve the property from. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Object | The found value. |
+
+[Tilia.DeveloperTools.Extension]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[GetValue(Object, String)]: #GetValueObject-String
+[GetValue(Object, String, Int32)]: #GetValueObject-String-Int32

--- a/Documentation/API/Extension/ObjectExtensions.md.meta
+++ b/Documentation/API/Extension/ObjectExtensions.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 97339106c3e155a4ca21f978febfc763
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Extension/README.md
+++ b/Documentation/API/Extension/README.md
@@ -1,0 +1,14 @@
+# Namespace Tilia.DeveloperTools.Extension
+
+### Classes
+
+#### [ObjectExtensions]
+
+Extended methods for the System.Object Type.
+
+#### [SerializedPropertyExtensions]
+
+Extended methods for the SerializedProperty Type.
+
+[ObjectExtensions]: ObjectExtensions.md
+[SerializedPropertyExtensions]: SerializedPropertyExtensions.md

--- a/Documentation/API/Extension/README.md.meta
+++ b/Documentation/API/Extension/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6d4113f878702648baffff64c15f291
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Extension/SerializedPropertyExtensions.md
+++ b/Documentation/API/Extension/SerializedPropertyExtensions.md
@@ -1,0 +1,75 @@
+# Class SerializedPropertyExtensions
+
+Extended methods for the SerializedProperty Type.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [GetTargetObjectOfProperty(SerializedProperty)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* SerializedPropertyExtensions
+
+##### Inherited Members
+
+System.Object.ToString()
+
+System.Object.Equals(System.Object)
+
+System.Object.Equals(System.Object, System.Object)
+
+System.Object.ReferenceEquals(System.Object, System.Object)
+
+System.Object.GetHashCode()
+
+System.Object.GetType()
+
+System.Object.MemberwiseClone()
+
+##### Namespace
+
+* [Tilia.DeveloperTools.Extension]
+
+##### Syntax
+
+```
+public static class SerializedPropertyExtensions
+```
+
+### Methods
+
+#### GetTargetObjectOfProperty(SerializedProperty)
+
+Gets the target object of the given property.
+
+##### Declaration
+
+```
+public static object GetTargetObjectOfProperty(this SerializedProperty property)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| SerializedProperty | property | The SerializedProperty to retrieve from. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Object | The target object. |
+
+[Tilia.DeveloperTools.Extension]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[GetTargetObjectOfProperty(SerializedProperty)]: #GetTargetObjectOfPropertySerializedProperty

--- a/Documentation/API/Extension/SerializedPropertyExtensions.md.meta
+++ b/Documentation/API/Extension/SerializedPropertyExtensions.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e0d11e7068c47b46bed4aea7379683f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides.meta
+++ b/Documentation/HowToGuides.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c71aecee2ccce5c49b0927e09430a6ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation.meta
+++ b/Documentation/HowToGuides/Installation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b34a66e654207c499854c1ea531f099
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -2,18 +2,67 @@
 
 > * Level: Beginner
 >
-> * Reading Time: {x} minutes
+> * Reading Time: 2 minutes
 >
-> * Checked with: {platform and version}
+> * Checked with: Unity 2018.3.14f1
 
 ## Introduction
 
-{Description of how the package is digested into the supported platform.}
+The Tilia Developer Tools provide a collection of useful tools to aid in development of Tilia solutions for the [Unity] software. These tools can be included in a Unity software project via the [Unity Package Manager].
 
 ## Let's Start
 
-### Step X
+### Step 1: Creating a Unity project
 
-{Describe each step with any useful imagery.}
+> You may skip this step if you already have a Unity project to import the package into.
+
+* Create a new project in the Unity software version `2018.3.10f1` (or above) using `3D Template` or open an existing project.
+
+### Step 2: Configuring the Unity project
+
+* Ensure the project `Scripting Runtime Version` is set to `.NET 4.x Equivalent`:
+  * In the Unity software select `Main Menu -> Edit -> Project Settings` to open the `Project Settings` inspector.
+  * Select `Player` from the left hand menu in the `Project Settings` window.
+  * In the `Player` settings panel expand `Other Settings`.
+  * Ensure the `Scripting Runtime Version` is set to `.NET 4.x Equivalent`.
+
+### Step 3: Adding the package to the Unity project manifest
+
+* Navigate to the `Packages` directory of your project.
+* Adjust the [project manifest file][Project-Manifest] `manifest.json` in a text editor.
+  * Ensure `https://registry.npmjs.org/` is part of `scopedRegistries`.
+    * Ensure `io.extendreality` is part of `scopes`.
+  * Add `io.extendreality.tilia.developertools.unity` to `dependencies`, stating the latest version.
+
+  A minimal example ends up looking like this. Please note that the version `X.Y.Z` stated here is to be replaced with [the latest released version][Latest-Release] which is currently [![Release][Version-Release]][Releases].
+  ```json
+  {
+    "scopedRegistries": [
+      {
+        "name": "npmjs",
+        "url": "https://registry.npmjs.org/",
+        "scopes": [
+          "io.extendreality"
+        ]
+      }
+    ],
+    "dependencies": {
+      "io.extendreality.tilia.developertools.unity": "X.Y.Z",
+      ...
+    }
+  }
+  ```
+* Switch back to the Unity software and wait for it to finish importing the added package.
 
 ### Done
+
+The `Tilia DeveloperTools Unity` package will now be available in your Unity project `Packages` directory ready for use in your project.
+
+The package will now also show up in the Unity Package Manager UI. From then on the package can be updated by selecting the package in the Unity Package Manager and clicking on the `Update` button or using the version selection UI.
+
+[Unity]: https://unity3d.com/
+[Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
+[Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.DeveloperTools.Unity.svg
+[Releases]: ../../../../../releases
+[Latest-Release]: ../../../../../releases/latest

--- a/Documentation/HowToGuides/Installation/README.md.meta
+++ b/Documentation/HowToGuides/Installation/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d10ec06c600473e418c26d0eb001ce27
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f724762134a89547bff28f5de56f151
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Event.meta
+++ b/Editor/Event.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21f0de1555581754eaaa8fda2318881e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Event/UnityEventSourceTracer.cs
+++ b/Editor/Event/UnityEventSourceTracer.cs
@@ -1,0 +1,225 @@
+﻿namespace Tilia.DeveloperTools.Event
+{
+    using System.Collections.Generic;
+    using Tilia.DeveloperTools.Extension;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.Events;
+    using Zinnia.Utility;
+
+    [InitializeOnLoad]
+    public class UnityEventSourceTracer : EditorWindow
+    {
+        private const string windowTitle = "UnityEvent Source Tracer";
+        private static EditorWindow promptWindow;
+        private Vector2 scrollPosition;
+        private Dictionary<Component, List<Component>> cache = new Dictionary<Component, List<Component>>();
+        private List<string> selectedComponents = new List<string>();
+        private List<Component> backingSelectedComponents = new List<Component>();
+        private int selectedComponentIndex;
+        private int lastSelectedIndex;
+        private GameObject selectedGameObejct;
+        private List<Component> foundCallers = new List<Component>();
+
+        public void OnGUI()
+        {
+            using (GUILayout.ScrollViewScope scrollViewScope = new GUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollViewScope.scrollPosition;
+                GUILayout.Label("Trace UnityEvent Sources", EditorStyles.boldLabel);
+
+                if (GUILayout.Button((cache.Count == 0 ? "B" : "Reb") + "uild Cache"))
+                {
+                    ClearSelectedComponents();
+                    BuildCache();
+                }
+
+                EditorHelper.DrawHorizontalLine();
+
+                if (cache.Count > 0)
+                {
+                    if (selectedComponents.Count > 0)
+                    {
+                        selectedComponentIndex = EditorGUILayout.Popup("Available Components", selectedComponentIndex, selectedComponents.ToArray());
+
+                        if (!selectedComponentIndex.Equals(lastSelectedIndex))
+                        {
+                            foundCallers.Clear();
+                        }
+
+                        EditorGUILayout.BeginHorizontal();
+                        EditorGUILayout.PrefixLabel(" ");
+                        if (GUILayout.Button("Find Source UnityEvents"))
+                        {
+                            foundCallers = GetAllCallingComponents(backingSelectedComponents[selectedComponentIndex]);
+                        }
+                        EditorGUILayout.EndHorizontal();
+
+                        EditorHelper.DrawHorizontalLine();
+
+                        if (foundCallers.Count > 0)
+                        {
+                            GUILayout.Label("Found Sources", EditorStyles.boldLabel);
+                        }
+                        else
+                        {
+                            EditorGUILayout.HelpBox("No Sources Found", MessageType.Info);
+                        }
+
+                        foreach (Component component in foundCallers)
+                        {
+                            if (GUILayout.Button(component.GetType().Name + " on " + component.name))
+                            {
+                                EditorGUIUtility.PingObject(component.gameObject);
+                            }
+                        }
+
+                        lastSelectedIndex = selectedComponentIndex;
+                    }
+                    else
+                    {
+                        BuildSelectedComponents();
+                    }
+                }
+            }
+
+            if (selectedGameObejct == null || !selectedGameObejct.Equals(Selection.activeGameObject))
+            {
+                ClearSelectedComponents();
+            }
+            selectedGameObejct = Selection.activeGameObject;
+        }
+
+        private List<Component> GetAllCallingComponents(Component target)
+        {
+            List<Component> results = new List<Component>();
+            if (cache.ContainsKey(target))
+            {
+                foreach (Component source in cache[target])
+                {
+                    results.Add(source);
+                }
+            }
+            return results;
+        }
+
+        private void ClearSelectedComponents()
+        {
+            selectedComponents.Clear();
+            backingSelectedComponents.Clear();
+            foundCallers.Clear();
+            selectedComponentIndex = 0;
+        }
+
+        private void BuildSelectedComponents()
+        {
+            ClearSelectedComponents();
+            GameObject obj = Selection.activeGameObject;
+            if (obj == null)
+            {
+                return;
+            }
+
+            List<Component> components = new List<Component>();
+            obj.GetComponents(components);
+            foreach (Component component in components)
+            {
+                backingSelectedComponents.Add(component);
+                selectedComponents.Add(ObjectNames.NicifyVariableName(component.GetType().Name));
+            }
+        }
+
+        private void BuildCache()
+        {
+            cache.Clear();
+            foreach (GameObject obj in Resources.FindObjectsOfTypeAll(typeof(GameObject)) as GameObject[])
+            {
+                if (EditorUtility.IsPersistent(obj) || obj.hideFlags != HideFlags.None)
+                {
+                    continue;
+                }
+
+                GetComponentsFromGameObject(obj);
+            }
+        }
+
+        private void GetComponentsFromGameObject(GameObject obj)
+        {
+            List<Component> components = new List<Component>();
+            obj.GetComponents(components);
+            foreach (Component component in components)
+            {
+                GetUnityEvent(component);
+            }
+        }
+
+        private void GetUnityEvent(Component component)
+        {
+            SerializedProperty iterator = new SerializedObject(component).GetIterator();
+            iterator.Next(true);
+            GetUnityEvent(component, iterator, 0);
+        }
+
+        private bool GetUnityEvent(Component component, SerializedProperty iterator, int depth)
+        {
+            bool hasData;
+            do
+            {
+                SerializedProperty persistentCalls = iterator.FindPropertyRelative("m_PersistentCalls.m_Calls");
+                bool isUnityEvent = persistentCalls != null;
+                if (isUnityEvent && persistentCalls.arraySize > 0)
+                {
+                    UnityEventBase unityEvent = iterator.GetTargetObjectOfProperty() as UnityEventBase;
+                    GetUnityEventListeners(component, unityEvent, iterator.displayName, iterator.propertyPath);
+                }
+                hasData = iterator.Next(!isUnityEvent);
+                if (hasData)
+                {
+                    if (iterator.depth < depth)
+                    {
+                        return hasData;
+                    }
+                    else if (iterator.depth > depth)
+                    {
+                        hasData = GetUnityEvent(component, iterator, iterator.depth);
+                    }
+                }
+            }
+            while (hasData);
+            return false;
+        }
+
+        private void GetUnityEventListeners(Component caller, UnityEventBase unityEvent, string shortName, string fullName)
+        {
+            for (int i = 0; i < unityEvent.GetPersistentEventCount(); i++)
+            {
+                string methodName = unityEvent.GetPersistentMethodName(i);
+                Object persistentTarget = unityEvent.GetPersistentTarget(i);
+                Component receiver = null;
+                try
+                {
+                    receiver = (Component)persistentTarget;
+                }
+                catch (System.Exception)
+                {
+                }
+
+                if (receiver != null && methodName != null && methodName != "")
+                {
+                    if (!cache.ContainsKey(receiver))
+                    {
+                        cache.Add(receiver, new List<Component>());
+                    }
+                    cache[receiver].Add(caller);
+                }
+            }
+        }
+
+        [MenuItem("Window/Tilia/DeveloperTools/" + windowTitle)]
+        private static void ShowWindow()
+        {
+            promptWindow = EditorWindow.GetWindow(typeof(UnityEventSourceTracer));
+            promptWindow.titleContent = new GUIContent(windowTitle);
+        }
+    }
+}

--- a/Editor/Event/UnityEventSourceTracer.cs.meta
+++ b/Editor/Event/UnityEventSourceTracer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c72f833a79d34cc4b9611c570eca6693
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Extension.meta
+++ b/Editor/Extension.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae668bfd4902f134d8be0f275d3fb273
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Extension/ObjectExtensions.cs
+++ b/Editor/Extension/ObjectExtensions.cs
@@ -1,0 +1,74 @@
+﻿namespace Tilia.DeveloperTools.Extension
+{
+    using System;
+    using System.Collections;
+    using System.Reflection;
+
+    /// <summary>
+    /// Extended methods for the <see cref="object"/> Type.
+    /// </summary>
+    public static class ObjectExtensions
+    {
+        /// <summary>
+        /// Gets the value for the given property name.
+        /// </summary>
+        /// <param name="source">The <see cref="object"/> to retrieve from.</param>
+        /// <param name="name">The name of the property to retrieve.</param>
+        /// <returns>The found value.</returns>
+        public static object GetValue(this object source, string name)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            Type type = source.GetType();
+
+            while (type != null)
+            {
+                FieldInfo fieldInfo = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                if (fieldInfo != null)
+                {
+                    return fieldInfo.GetValue(source);
+                }
+
+                PropertyInfo propertyInfo = type.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (propertyInfo != null)
+                {
+                    return propertyInfo.GetValue(source, null);
+                }
+
+                type = type.BaseType;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the value for the given property name.
+        /// </summary>
+        /// <param name="source">The <see cref="object"/> to retrieve from.</param>
+        /// <param name="name">The name of the property to retrieve.</param>
+        /// <param name="index">The index to retrieve the property from.</param>
+        /// <returns>The found value.</returns>
+        public static object GetValue(this object source, string name, int index)
+        {
+            IEnumerable enumerable = source.GetValue(name) as IEnumerable;
+            if (enumerable == null)
+            {
+                return null;
+            }
+
+            IEnumerator enumerator = enumerable.GetEnumerator();
+
+            for (int enumeratorIndex = 0; enumeratorIndex <= index; enumeratorIndex++)
+            {
+                if (!enumerator.MoveNext())
+                {
+                    return null;
+                }
+            }
+            return enumerator.Current;
+        }
+    }
+}

--- a/Editor/Extension/ObjectExtensions.cs.meta
+++ b/Editor/Extension/ObjectExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86385679ed86931438bc50a9d2db6a91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Extension/SerializedPropertyExtensions.cs
+++ b/Editor/Extension/SerializedPropertyExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace Tilia.DeveloperTools.Extension
+{
+    using UnityEditor;
+
+    /// <summary>
+    /// Extended methods for the <see cref="SerializedProperty"/> Type.
+    /// </summary>
+    public static class SerializedPropertyExtensions
+    {
+        /// <summary>
+        /// Gets the target object of the given property.
+        /// </summary>
+        /// <param name="property">The <see cref="SerializedProperty"/> to retrieve from.</param>
+        /// <returns>The target object.</returns>
+        public static object GetTargetObjectOfProperty(this SerializedProperty property)
+        {
+            string path = property.propertyPath.Replace(".Array.data[", "[");
+            object obj = property.serializedObject.targetObject;
+            string[] elements = path.Split('.');
+            foreach (string element in elements)
+            {
+                if (element.Contains("["))
+                {
+                    string elementName = element.Substring(0, element.IndexOf("["));
+                    int index = System.Convert.ToInt32(element.Substring(element.IndexOf("[")).Replace("[", "").Replace("]", ""));
+                    obj = obj.GetValue(elementName, index);
+                }
+                else
+                {
+                    obj = obj.GetValue(element);
+                }
+            }
+            return obj;
+        }
+    }
+}

--- a/Editor/Extension/SerializedPropertyExtensions.cs.meta
+++ b/Editor/Extension/SerializedPropertyExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 796a4bb4abd62ab4ca596e9039678638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.DeveloperTools.Unity.Editor.asmdef
+++ b/Editor/Tilia.DeveloperTools.Unity.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Tilia.DeveloperTools.Unity.Editor",
+    "references": [
+        "Zinnia.Editor"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Editor/Tilia.DeveloperTools.Unity.Editor.asmdef.meta
+++ b/Editor/Tilia.DeveloperTools.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 558a3db650df7d242b85a56fcd35d502
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 61deb771d66f5d846b4db0312fad5836
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tilia logo][Tilia-Image]](#)
 
-> ### Tilia {scope} {feature} {platform?}
-> {Description of feature}.
+> ### Developer Tools for the Unity software
+> A collection of useful developer tools for the Unity software.
 
 [![Release][Version-Release]][Releases]
 [![License][License-Badge]][License]
@@ -9,9 +9,9 @@
 
 ## Introduction
 
-{Introduction into the purpose of the feature.}
+The Tilia Developer Tools provide a collection of useful tools to aid in development of Tilia solutions for the Unity software.
 
-> **Requires** {platform and minimum version number}.
+> **Requires** the Unity software version `2018.3.10f1` (or above).
 
 ## Getting Started
 
@@ -35,9 +35,9 @@ Please refer to the Extend Reality [Code of Conduct].
 
 Code released under the [MIT License][License].
 
-[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/{project_type}
+[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.DeveloperTools.Unity.svg
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.DeveloperTools.Unity.svg
+[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/UNITY3D.md
 
 [Tilia-Image]: https://user-images.githubusercontent.com/1029673/67681496-5bf10700-f985-11e9-9413-e61801b6eab5.png
 [License]: LICENSE.md

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ab9834ba448983a4d9fae28574952912
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,61 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Editor/**.cs",
+            "Runtime/**.cs"
+          ]
+        }
+      ],
+      "dest": "_TEMP_DOCS/API",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "_TEMP_DOCS/API/**.yml",
+          "_TEMP_DOCS/API/index.md"
+        ]
+      },
+      {
+        "files": [
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "dest": "_TEMP_DOCS/output",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docfx.json.meta
+++ b/docfx.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e065309e7f75e7240af7a68bbcc81766
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-    "name": "io.extendreality.tilia.{scope}.{feature}.{platform?}",
-    "displayName": "Tilia {scope}.{feature}.{platform?}",
-    "description": "{Description of feature.}",
+    "name": "io.extendreality.tilia.developertools.unity",
+    "displayName": "Tilia DeveloperTools Unity",
+    "description": "A collection of useful developer tools for the Unity software.",
     "version": "1.0.0",
     "unity": "2018.3",
     "unityRelease": "10f1",
     "keywords": [
-        "pattern"
+        "developer",
+        "tools"
     ],
-    "homepage": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/",
+    "homepage": "https://github.com/ExtendRealityLtd/Tilia.DeveloperTools.Unity/",
     "bugs": {
-        "url": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/issues"
+        "url": "https://github.com/ExtendRealityLtd/Tilia.DeveloperTools.Unity/issues"
     },
     "repository": {
         "type": "git",
-        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.git"
+        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.DeveloperTools.Unity.git"
     },
     "license": "MIT",
     "author": {
@@ -23,7 +24,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "X.Y.Z"
+        "io.extendreality.zinnia.unity": "1.28.1"
     },
     "files": [
         "*.md",
@@ -31,6 +32,7 @@
         "*.asmdef",
         "*.xml",
         "Documentation",
-        "Runtime"
+        "Editor",
+        "docfx.json"
     ]
 }

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cd081833092e9494eb918543a01656c1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The UnityEventSourceTracer editor window allows for the tracing
of any UnityEvent that is affecting a component. The window works
by caching all UnityEvent listeners and then when a component is
selected, the tracer will reverse look up any UnityEvent listeners
that are affecting the selected component.

The relevant docs and initial readmes have also been added too.