### PR TITLE
fix(Event): prefix GameObject component to prevent overriding

### DIFF
--- a/Editor/Event/UnityEventSourceTracer.cs
+++ b/Editor/Event/UnityEventSourceTracer.cs
@@ -124,7 +124,7 @@
             obj.GetComponents(components);
 
             backingSelectedComponents.Add(obj);
-            selectedComponents.Add(ObjectNames.NicifyVariableName(obj.name));
+            selectedComponents.Add(ObjectNames.NicifyVariableName("GameObject (" + obj.name + ")"));
             foreach (Component component in components)
             {
                 backingSelectedComponents.Add(component);


### PR DESCRIPTION
There was an issue where if the GameObject component name was the
same as an actual component on the GameObject then the GameObject
would override the component object and only the GameObject would
show up in the list.

This has been fixed by simply prefixing the GameObject element
in the list with the word "GameObect (<actual name>)" to ensure
uniqueness.